### PR TITLE
Add specs for #sunk? method and #hit method.

### DIFF
--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -12,8 +12,27 @@ RSpec.describe Ship do
 
     it 'has attributes' do
       expect(@cruiser.name).to eq("Cruiser")
+      
       expect(@cruiser.length).to eq(3)
+
       expect(@cruiser.health).to eq(3)
+    end
+  end
+
+  describe '#sunk?' do 
+    it 'can check if boat sunk' do
+      expect(@cruiser.sunk?).to be(false)
+    end
+  end
+
+  describe '#hit' do
+    it 'can hit ship' do
+      expect(@cruiser.sunk?).to be(false)
+      
+      cruiser.hit
+
+      expect(@cruiser.sunk?).to be(true)
+
     end
   end
 end


### PR DESCRIPTION
I added the specs for the #sunk? method and #hit method. The sunk method is failing right now because it is returning true so line 24 if failing. I think it's failing because line 11 in ship.rb returns true since health is over 0. 