### PR TITLE
Board/validplacement vertical

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,5 +1,6 @@
 class Board
   attr_reader :cells
+  
   def initialize
     @cells = {
       'A1' => Cell.new('A1'),
@@ -25,34 +26,28 @@ class Board
     @cells.keys.include?(coordinate)
   end
 
-  def valid_placement?(ship, ship_coordinates)
-    ## first validates ship length
-    valid_length?(ship, ship_coordinates) && 
-
-    ## if the ship is being placed vertically --> check for valid vertical placement
-    if ship_coordinates.first[1] == ship_coordinates[1][1] && ship_coordinates[1][1] == ship_coordinates.last[1]
-      valid_vertical?(ship, ship_coordinates)
-    else ## otherwise checks for valid horizontal placement if not vertical (diagonals will fail this check)
-      valid_horizontal?(ship, ship_coordinates)
-    end
-  end
-
   def valid_length?(ship, ship_coordinates)
     ship_coordinates.count == ship.length
   end
 
-  def valid_horizontal?(ship, ship_coordinates)
+  def valid_horizontal_placement?(ship, ship_coordinates)
     range = ship_coordinates.first..ship_coordinates.last
     array = range.to_a
     array == ship_coordinates
   end
 
-  # check for appropriate vertical placement by looking at each consecutive pair of coordinates
-  # ie: ["B1", "C1"], then ["C1", "D1"], and assessing if the letters are consecutive ordinal values
-  def valid_vertical?(ship, ship_coordinates)
+  def valid_vertical_placement?(ship, ship_coordinates)
     ship_coordinates.each_cons(2).all? do |ship_coordinate, next_ship_coordinate|
-      # ship_coordinate[1] == next_ship_coordinate[1] &&
       ship_coordinate[0].ord + 1 == next_ship_coordinate[0].ord
+    end
+  end
+
+  def valid_placement?(ship, ship_coordinates)
+    valid_length?(ship, ship_coordinates) && 
+    if ship_coordinates.first[1] == ship_coordinates[1][1] && ship_coordinates[1][1] == ship_coordinates.last[1]
+      valid_vertical_placement?(ship, ship_coordinates)
+    else
+      valid_horizontal_placement?(ship, ship_coordinates)
     end
   end
 

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -22,26 +22,38 @@ class Board
   end
 
   def valid_coordinate?(coordinate)  
-    # @cells.each do |key, value|
-    #   return true if value.coordinate == coordinate
-    # end
-    # false
     @cells.keys.include?(coordinate)
   end
 
   def valid_placement?(ship, ship_coordinates)
-    range = ship_coordinates.first..ship_coordinates.last
-    array  = range.to_a
+    ## first validates ship length
+    valid_length?(ship, ship_coordinates) && 
 
-    valid_length?(ship, ship_coordinates) && array == ship_coordinates
-
-    # return false unless ship_coordinates.count == ship.length
-    # return false unless array == ship_coordinates
-    
+    ## if the ship is being placed vertically --> check for valid vertical placement
+    if ship_coordinates.first[1] == ship_coordinates[1][1] && ship_coordinates[1][1] == ship_coordinates.last[1]
+      valid_vertical?(ship, ship_coordinates)
+    else ## otherwise checks for valid horizontal placement if not vertical (diagonals will fail this check)
+      valid_horizontal?(ship, ship_coordinates)
+    end
   end
 
   def valid_length?(ship, ship_coordinates)
     ship_coordinates.count == ship.length
+  end
+
+  def valid_horizontal?(ship, ship_coordinates)
+    range = ship_coordinates.first..ship_coordinates.last
+    array = range.to_a
+    array == ship_coordinates
+  end
+
+  # check for appropriate vertical placement by looking at each consecutive pair of coordinates
+  # ie: ["B1", "C1"], then ["C1", "D1"], and assessing if the letters are consecutive ordinal values
+  def valid_vertical?(ship, ship_coordinates)
+    ship_coordinates.each_cons(2).all? do |ship_coordinate, next_ship_coordinate|
+      # ship_coordinate[1] == next_ship_coordinate[1] &&
+      ship_coordinate[0].ord + 1 == next_ship_coordinate[0].ord
+    end
   end
 
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -22,15 +22,26 @@ class Board
   end
 
   def valid_coordinate?(coordinate)  
-    @cells.each do |key, value|
-      return true if value.coordinate == coordinate
-    end
-    false
+    # @cells.each do |key, value|
+    #   return true if value.coordinate == coordinate
+    # end
+    # false
+    @cells.keys.include?(coordinate)
   end
 
   def valid_placement?(ship, ship_coordinates)
     range = ship_coordinates.first..ship_coordinates.last
     array  = range.to_a
-    ship_coordinates.count == ship.length && array == ship_coordinates
+
+    valid_length?(ship, ship_coordinates) && array == ship_coordinates
+
+    # return false unless ship_coordinates.count == ship.length
+    # return false unless array == ship_coordinates
+    
   end
+
+  def valid_length?(ship, ship_coordinates)
+    ship_coordinates.count == ship.length
+  end
+
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -28,29 +28,46 @@ RSpec.describe Board do
     end
   end
 
-  describe '#valid_placement?' do
+  describe '#valid_length?' do
     it 'can check for valid ship length' do
-      expect(@board.valid_placement?(@cruiser, ['A1', 'A2'])).to be(false)
-      expect(@board.valid_placement?(@submarine, ['A2', 'A3', 'A4'])).to be(false)
-      expect(@board.valid_placement?(@cruiser, ['B2', 'C2', 'D2'])).to be(true)
-      expect(@board.valid_placement?(@submarine, ['A4', 'B4'])).to be(true)
-    end
-
-    it 'can check for consecutive horizontal coordinates' do
-      expect(@board.valid_placement?(@cruiser, ['A1', 'A2', 'A4'])).to be(false)
-      expect(@board.valid_placement?(@submarine, ['A1', 'C1'])).to be(false)
-      expect(@board.valid_placement?(@cruiser, ['A3', 'A2', 'A1'])).to be(false)
-      expect(@board.valid_placement?(@submarine, ['C1', 'B1'])).to be(false)
-    end
-    
-    it 'can check for diagonal coordinates' do
-      expect(@board.valid_placement?(@cruiser, ['A1', 'B2', 'C3'])).to be(false)
-      expect(@board.valid_placement?(@submarine, ['C2', 'D3'])).to be(false)
-    end
-    
-    it 'it can check for valid ship length and consecutive coordinates' do
-      expect(@board.valid_placement?(@submarine, ['A1', 'A2'])).to be(true)
-      expect(@board.valid_placement?(@cruiser, ['B1', 'C1', 'D1'])).to be(true)
+      expect(@board.valid_length?(@cruiser, ['A1', 'A2'])).to be(false)
+      expect(@board.valid_length?(@submarine, ['A2', 'A3', 'A4'])).to be(false)
+      expect(@board.valid_length?(@cruiser, ['B2', 'C2', 'D2'])).to be(true)
+      expect(@board.valid_length?(@submarine, ['A4', 'B4'])).to be(true)
     end
   end
+
+  describe '#valid_horizontal_placement?' do
+    it 'can check for consecutive horizontal coordinates' do
+      expect(@board.valid_horizontal_placement?(@cruiser, ['A1', 'A2', 'A4'])).to be(false)
+      expect(@board.valid_horizontal_placement?(@submarine, ['A1', 'C1'])).to be(false)
+      expect(@board.valid_horizontal_placement?(@cruiser, ['A3', 'A2', 'A1'])).to be(false)
+      expect(@board.valid_horizontal_placement?(@submarine, ['C1', 'B1'])).to be(false)
+      expect(@board.valid_horizontal_placement?(@submarine, ['B1', 'B2'])).to be(true)
+      expect(@board.valid_horizontal_placement?(@cruiser, ['D2', 'D3', 'D4'])).to be(true)
+      expect(@board.valid_horizontal_placement?(@cruiser, ['A1', 'B2', 'C3'])).to be(false)
+    end
+  end
+
+  describe '#valid_vertical_placement?' do
+    it 'can check for consecutive vertical coordinates' do
+      expect(@board.valid_vertical_placement?(@submarine, ['A1', 'A2'])).to be(false)
+      expect(@board.valid_vertical_placement?(@cruiser, ['C2', 'C3', 'C4'])).to be(false)
+      expect(@board.valid_vertical_placement?(@cruiser, ['A1', 'B1', 'C1'])).to be(true)
+      expect(@board.valid_vertical_placement?(@submarine, ['C2', 'D2'])).to be(true)
+      expect(@board.valid_vertical_placement?(@cruiser, ['B3', 'C3', 'D3'])).to be(true)
+    end
+  end
+
+  describe '#valid_placement?' do
+    it 'it can check for valid ship length and consecutive horizontal/vertical coordinates' do
+      expect(@board.valid_placement?(@cruiser, ['A1', 'B2', 'C3'])).to be(false)
+      expect(@board.valid_placement?(@submarine, ['C2', 'D3'])).to be(false)
+      expect(@board.valid_placement?(@submarine, ['A1', 'A2'])).to be(true)
+      expect(@board.valid_placement?(@cruiser, ['B1', 'C1', 'D1'])).to be(true)
+      expect(@board.valid_placement?(@cruiser, ['A1', 'B1', 'C1'])).to be(true)
+      expect(@board.valid_placement?(@cruiser, ['B3', 'C3', 'D3'])).to be(true)
+    end
+  end
+
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -32,9 +32,11 @@ RSpec.describe Board do
     it 'can check for valid ship length' do
       expect(@board.valid_placement?(@cruiser, ['A1', 'A2'])).to be(false)
       expect(@board.valid_placement?(@submarine, ['A2', 'A3', 'A4'])).to be(false)
+      expect(@board.valid_placement?(@cruiser, ['B2', 'C2', 'D2'])).to be(true)
+      expect(@board.valid_placement?(@submarine, ['A4', 'B4'])).to be(true)
     end
 
-    it 'can check for consecutive coordinates' do
+    it 'can check for consecutive horizontal coordinates' do
       expect(@board.valid_placement?(@cruiser, ['A1', 'A2', 'A4'])).to be(false)
       expect(@board.valid_placement?(@submarine, ['A1', 'C1'])).to be(false)
       expect(@board.valid_placement?(@cruiser, ['A3', 'A2', 'A1'])).to be(false)


### PR DESCRIPTION
**1) small change to` #valid_coordinate `to simplify the logic
2) splits `#valid_placement? `into three helper methods:**

-    first checks `#valid_length?` (to see if the number of coordinates equals the size of the ship)
-    if the ship is being placed vertically, then calls `#valid_vertical_placement? `which returns true if the consecutive pairs of coordinates are always one letter greater than the previous (by comparing ordinal number of the coordinate's letter component)
-   if the ship is not being placed vertically, then calls `#valid_horizontal_placement? `which creates a new array from the ship_coordinates' range, and compares this to the ship_coordinates (they should be equal if the ship is horizontal). This test will always fail if the ship is being placed diagonally.
- in order for `#valid_placement? `to return true, it needs `#valid_length? `AND (either `#valid_vertical_placement?` OR `#valid_horizontal_placement?`) to pass

**3) added more robust testing so each of the helper methods of `#valid_placement? `also have tests**