### PR TITLE
Board/ships

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -50,13 +50,22 @@ class Board
 
   def valid_placement?(ship, ship_coordinates)
     valid_length?(ship, ship_coordinates) &&
-    consecutive_coordinates?(ship, ship_coordinates)
+    consecutive_coordinates?(ship, ship_coordinates) &&
+    no_overlapping_ships?(ship, ship_coordinates)
   end
 
   def place(ship, ship_coordinates)
     ship_coordinates.each do |coordinate|
       @cells[coordinate].place_ship(ship)
     end
+  end
+
+  def no_overlapping_ships?(ship, ship_coordinates)
+    ship_coordinates.each do |coordinate|
+      cell = @cells[coordinate]
+      return false unless cell.empty?
+    end
+    true
   end
 
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -30,25 +30,27 @@ class Board
     ship_coordinates.count == ship.length
   end
 
-  def valid_horizontal_placement?(ship, ship_coordinates)
-    range = ship_coordinates.first..ship_coordinates.last
-    array = range.to_a
-    array == ship_coordinates
+  def consecutive_coordinates?(ship, ship_coordinates)
+    if ship_coordinates.first[0] == ship_coordinates[1][0] && ship_coordinates[1][0] == ship_coordinates.last[0]
+      range = ship_coordinates.first..ship_coordinates.last
+      array = range.to_a
+      array == ship_coordinates
+    elsif ship_coordinates.first[1] == ship_coordinates[1][1] && ship_coordinates[1][1] == ship_coordinates.last[1]
+      consecutive_vertical_coordinates?(ship, ship_coordinates)
+    else 
+      false # diagonal always returns false
+    end
   end
 
-  def valid_vertical_placement?(ship, ship_coordinates)
+  def consecutive_vertical_coordinates?(ship, ship_coordinates)
     ship_coordinates.each_cons(2).all? do |ship_coordinate, next_ship_coordinate|
       ship_coordinate[0].ord + 1 == next_ship_coordinate[0].ord
     end
   end
 
   def valid_placement?(ship, ship_coordinates)
-    valid_length?(ship, ship_coordinates) && 
-    if ship_coordinates.first[1] == ship_coordinates[1][1] && ship_coordinates[1][1] == ship_coordinates.last[1]
-      valid_vertical_placement?(ship, ship_coordinates)
-    else
-      valid_horizontal_placement?(ship, ship_coordinates)
-    end
+    valid_length?(ship, ship_coordinates) &&
+    consecutive_coordinates?(ship, ship_coordinates)
   end
 
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -53,4 +53,10 @@ class Board
     consecutive_coordinates?(ship, ship_coordinates)
   end
 
+  def place(ship, ship_coordinates)
+    ship_coordinates.each do |coordinate|
+      @cells[coordinate].place_ship(ship)
+    end
+  end
+
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -72,4 +72,19 @@ RSpec.describe Board do
     end
   end
 
+  describe '#place' do 
+    it 'can place a ship' do 
+      @board.place(@cruiser, ['A1', 'A2', 'A3'])
+      cell_1 = @board.cells['A1']
+      cell_2 = @board.cells['A2']
+      cell_3 = @board.cells['A3']
+      expect(cell_1.ship).to eq(@cruiser)
+      expect(cell_2.ship).to eq(@cruiser)
+      expect(cell_3.ship).to eq(@cruiser)
+      expect(cell_1.ship).to eq(cell_2.ship)
+      expect(cell_2.ship).to eq(cell_3.ship)
+      expect(cell_1.ship).to eq(cell_3.ship)
+    end
+  end
+
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -87,4 +87,18 @@ RSpec.describe Board do
     end
   end
 
+  describe '#no_overlapping_ships' do
+    it 'can check for overlapping ships' do
+      expect(@board.no_overlapping_ships?(@submarine, ['A1', 'B1'])).to be(true)
+      @board.place(@cruiser, ['A1', 'A2', 'A3'])
+      expect(@board.no_overlapping_ships?(@submarine, ['A1', 'B1'])).to be(false)
+    end
+
+    it 'can check for overlapping ships from the #valid_placement? method' do
+      expect(@board.valid_placement?(@cruiser, ['A2', 'B2', 'C2'])).to be(true)
+      @board.place(@submarine, ['A2', 'A3'])
+      expect(@board.valid_placement?(@cruiser, ['A2', 'B2', 'C2'])).to be(false)
+    end
+  end
+
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -37,25 +37,25 @@ RSpec.describe Board do
     end
   end
 
-  describe '#valid_horizontal_placement?' do
+  describe '#consecutive_coordinates?' do
     it 'can check for consecutive horizontal coordinates' do
-      expect(@board.valid_horizontal_placement?(@cruiser, ['A1', 'A2', 'A4'])).to be(false)
-      expect(@board.valid_horizontal_placement?(@submarine, ['A1', 'C1'])).to be(false)
-      expect(@board.valid_horizontal_placement?(@cruiser, ['A3', 'A2', 'A1'])).to be(false)
-      expect(@board.valid_horizontal_placement?(@submarine, ['C1', 'B1'])).to be(false)
-      expect(@board.valid_horizontal_placement?(@submarine, ['B1', 'B2'])).to be(true)
-      expect(@board.valid_horizontal_placement?(@cruiser, ['D2', 'D3', 'D4'])).to be(true)
-      expect(@board.valid_horizontal_placement?(@cruiser, ['A1', 'B2', 'C3'])).to be(false)
+      expect(@board.consecutive_coordinates?(@cruiser, ['A1', 'A2', 'A4'])).to be(false)
+      expect(@board.consecutive_coordinates?(@submarine, ['A1', 'C1'])).to be(false)
+      expect(@board.consecutive_coordinates?(@cruiser, ['A3', 'A2', 'A1'])).to be(false)
+      expect(@board.consecutive_coordinates?(@submarine, ['C1', 'B1'])).to be(false)
+      expect(@board.consecutive_coordinates?(@submarine, ['B1', 'B2'])).to be(true)
+      expect(@board.consecutive_coordinates?(@cruiser, ['D2', 'D3', 'D4'])).to be(true)
+      expect(@board.consecutive_coordinates?(@cruiser, ['A1', 'B2', 'C3'])).to be(false)
     end
   end
 
-  describe '#valid_vertical_placement?' do
+  describe '#consecutive_vertical_coordinates?' do
     it 'can check for consecutive vertical coordinates' do
-      expect(@board.valid_vertical_placement?(@submarine, ['A1', 'A2'])).to be(false)
-      expect(@board.valid_vertical_placement?(@cruiser, ['C2', 'C3', 'C4'])).to be(false)
-      expect(@board.valid_vertical_placement?(@cruiser, ['A1', 'B1', 'C1'])).to be(true)
-      expect(@board.valid_vertical_placement?(@submarine, ['C2', 'D2'])).to be(true)
-      expect(@board.valid_vertical_placement?(@cruiser, ['B3', 'C3', 'D3'])).to be(true)
+      expect(@board.consecutive_vertical_coordinates?(@submarine, ['A1', 'A2'])).to be(false)
+      expect(@board.consecutive_vertical_coordinates?(@cruiser, ['C2', 'C3', 'C4'])).to be(false)
+      expect(@board.consecutive_vertical_coordinates?(@cruiser, ['A1', 'B1', 'C1'])).to be(true)
+      expect(@board.consecutive_vertical_coordinates?(@submarine, ['C2', 'D2'])).to be(true)
+      expect(@board.consecutive_vertical_coordinates?(@cruiser, ['B3', 'C3', 'D3'])).to be(true)
     end
   end
 
@@ -63,7 +63,9 @@ RSpec.describe Board do
     it 'it can check for valid ship length and consecutive horizontal/vertical coordinates' do
       expect(@board.valid_placement?(@cruiser, ['A1', 'B2', 'C3'])).to be(false)
       expect(@board.valid_placement?(@submarine, ['C2', 'D3'])).to be(false)
+      expect(@board.valid_placement?(@cruiser, ['D1', 'C2', 'B3'])).to be(false)
       expect(@board.valid_placement?(@submarine, ['A1', 'A2'])).to be(true)
+      expect(@board.valid_placement?(@submarine, ['C3', 'C4'])).to be(true)
       expect(@board.valid_placement?(@cruiser, ['B1', 'C1', 'D1'])).to be(true)
       expect(@board.valid_placement?(@cruiser, ['A1', 'B1', 'C1'])).to be(true)
       expect(@board.valid_placement?(@cruiser, ['B3', 'C3', 'D3'])).to be(true)


### PR DESCRIPTION
Iteration 2 is now complete except for the last part (rendering).

New methods (and associated tests) include:
- `#place` : this method takes in a Ship object and a set of coordinates as arguments, and places the Ship object on the cells located at those coordinates (all of those cells will contain the same Ship object)
- `#no_overlapping_ships?`: this method ensures that any Ship object being placed on the board is not being placed on any cell currently occupied by another existing Ship object (returns false if another Ship is already present on any of the cells corresponding to the ship_coordinates argument)
- updated `#valid_placement?` to also evaluate for `#no_overlapping_ships?` (if there are currently no ships on the board, then the #no_overlapping_ships? method will just return true)
-  I also updated the helper methods for #valid_placement? with more appropriate/simplified names and moved a little code around for SRP reasons / readability